### PR TITLE
Invalid OK-ACCESS-TIMESTAMP header fix

### DIFF
--- a/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/client/APIHttpClient.java
+++ b/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/client/APIHttpClient.java
@@ -66,7 +66,7 @@ public class APIHttpClient {
         clientBuilder.retryOnConnectionFailure(this.config.isRetryOnConnectionFailure());
         clientBuilder.addInterceptor((Interceptor.Chain chain) -> {
             final Request.Builder requestBuilder = chain.request().newBuilder();
-            final String timestamp = DateUtils.getUnixTimeWithMs();
+            final String timestamp = DateUtils.getUnixTime();
             //打印首行时间戳
             System.out.println("时间戳timestamp={" + timestamp + "}");
 

--- a/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/client/APIHttpClient.java
+++ b/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/client/APIHttpClient.java
@@ -66,7 +66,7 @@ public class APIHttpClient {
         clientBuilder.retryOnConnectionFailure(this.config.isRetryOnConnectionFailure());
         clientBuilder.addInterceptor((Interceptor.Chain chain) -> {
             final Request.Builder requestBuilder = chain.request().newBuilder();
-            final String timestamp = DateUtils.getUnixTime();
+            final String timestamp = DateUtils.getUnixTimeWithMs();
             //打印首行时间戳
             System.out.println("时间戳timestamp={" + timestamp + "}");
 

--- a/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/utils/DateUtils.java
+++ b/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/utils/DateUtils.java
@@ -6,8 +6,19 @@ import java.math.BigDecimal;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
 import java.util.Date;
+import java.util.Locale;
 import java.util.TimeZone;
+
+import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE;
+import static java.time.temporal.ChronoField.HOUR_OF_DAY;
+import static java.time.temporal.ChronoField.MILLI_OF_SECOND;
+import static java.time.temporal.ChronoField.MINUTE_OF_HOUR;
+import static java.time.temporal.ChronoField.SECOND_OF_MINUTE;
 
 /**
  * Date Utils  <br/>
@@ -26,6 +37,22 @@ public class DateUtils {
     public static String TIME_STYLE_S6 = "yyyyMMddHHmmssS";
     public static String TIME_STYLE_S7 = "yyyy年MM月dd日HH时mm分ss秒";
     public static SimpleDateFormat SDF = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.S'Z'");
+
+    private static DateTimeFormatter RFC3339_MS = new DateTimeFormatterBuilder()
+            .parseCaseInsensitive()
+            .append(ISO_LOCAL_DATE)
+            .appendLiteral('T')
+            .appendValue(HOUR_OF_DAY, 2)
+            .appendLiteral(':')
+            .appendValue(MINUTE_OF_HOUR, 2)
+            .optionalStart()
+            .appendLiteral(':')
+            .appendValue(SECOND_OF_MINUTE, 2)
+            .appendLiteral('.')
+            .appendValue(MILLI_OF_SECOND, 3)
+            .parseLenient()
+            .appendOffsetId()
+            .parseStrict().toFormatter(Locale.US);
 
     static {
         DateUtils.SDF.setTimeZone(TimeZone.getTimeZone("UTC"));
@@ -118,6 +145,25 @@ public class DateUtils {
         //可以有效解决字符串下标越界的问题
         return new StringBuilder().append(nowStr.toString()).toString();
         //return new StringBuilder().append(nowStr.substring(0,nowStr.lastIndexOf("."))).append(nowStr.substring(nowStr.lastIndexOf(".")).substring(0,4)).append(nowStr.substring(nowStr.length()-1)).toString();
+    }
+
+    public static String getUnixTimeWithMs() {
+        DateTimeFormatter RFC3339_FORMATTER = new DateTimeFormatterBuilder()
+                .parseCaseInsensitive()
+                .append(ISO_LOCAL_DATE)
+                .appendLiteral('T')
+                .appendValue(HOUR_OF_DAY, 2)
+                .appendLiteral(':')
+                .appendValue(MINUTE_OF_HOUR, 2)
+                .optionalStart()
+                .appendLiteral(':')
+                .appendValue(SECOND_OF_MINUTE, 2)
+                .appendLiteral('.')
+                .appendValue(MILLI_OF_SECOND, 3)
+                .parseLenient()
+                .appendOffsetId()
+                .parseStrict().toFormatter(Locale.US);
+        return ZonedDateTime.ofInstant(Instant.now(), ZoneOffset.UTC).format(RFC3339_FORMATTER);
     }
 
     /**Date

--- a/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/utils/DateUtils.java
+++ b/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/utils/DateUtils.java
@@ -38,7 +38,7 @@ public class DateUtils {
     public static String TIME_STYLE_S7 = "yyyy年MM月dd日HH时mm分ss秒";
     public static SimpleDateFormat SDF = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.S'Z'");
 
-    private static DateTimeFormatter RFC3339_MS = new DateTimeFormatterBuilder()
+    private static DateTimeFormatter RFC3339_FORMATTER = new DateTimeFormatterBuilder()
             .parseCaseInsensitive()
             .append(ISO_LOCAL_DATE)
             .appendLiteral('T')
@@ -141,28 +141,6 @@ public class DateUtils {
      * UNIX timestamp ISO 8601 rule eg: 2018-02-03T05:34:14.110Z
      */
     public static String getUnixTime() {
-        StringBuilder nowStr = new StringBuilder(Instant.now().toString());
-        //可以有效解决字符串下标越界的问题
-        return new StringBuilder().append(nowStr.toString()).toString();
-        //return new StringBuilder().append(nowStr.substring(0,nowStr.lastIndexOf("."))).append(nowStr.substring(nowStr.lastIndexOf(".")).substring(0,4)).append(nowStr.substring(nowStr.length()-1)).toString();
-    }
-
-    public static String getUnixTimeWithMs() {
-        DateTimeFormatter RFC3339_FORMATTER = new DateTimeFormatterBuilder()
-                .parseCaseInsensitive()
-                .append(ISO_LOCAL_DATE)
-                .appendLiteral('T')
-                .appendValue(HOUR_OF_DAY, 2)
-                .appendLiteral(':')
-                .appendValue(MINUTE_OF_HOUR, 2)
-                .optionalStart()
-                .appendLiteral(':')
-                .appendValue(SECOND_OF_MINUTE, 2)
-                .appendLiteral('.')
-                .appendValue(MILLI_OF_SECOND, 3)
-                .parseLenient()
-                .appendOffsetId()
-                .parseStrict().toFormatter(Locale.US);
         return ZonedDateTime.ofInstant(Instant.now(), ZoneOffset.UTC).format(RFC3339_FORMATTER);
     }
 


### PR DESCRIPTION
Each response from the bitFlyer API was with this error: Invalid OK-ACCESS-TIMESTAMP. The reason is the timestamp format. Only 3 digits for partial of seconds (it means milliseconds) are allowed.